### PR TITLE
allow rake to continue if you get a 404 error

### DIFF
--- a/lib/pmc-id-converter.rb
+++ b/lib/pmc-id-converter.rb
@@ -34,24 +34,28 @@ class PMCIDConverter
       uri = URI(PMC_API_URL)
       ar = URI.decode_www_form(uri.query) << ["ids", id]
       uri.query = URI.encode_www_form(ar)
-      open(uri) do |json|
-        response = JSON.parse json.read
-        unless response["status"] == "ok"
-          raise PMCIDConverterError.new("PMC ID Converter API returned an error: #{response['message']}", response)
+      begin
+        open(uri) do |json|
+          response = JSON.parse json.read
+          unless response["status"] == "ok"
+            raise PMCIDConverterError.new("PMC ID Converter API returned an error: #{response['message']}", response)
+          end
+          unless response["records"].length > 0
+            raise PMCIDConverterError.new("PMC ID Converter API returned no results", response)
+          end
+          first_result = response["records"].first
+          if first_result["status"] == "error"
+            raise PMCIDConverterError.new("PMC ID Converter API could not find this ID: #{id}", response)
+          end
+          {
+            :pmcid => first_result["pmcid"],
+            :pmid => first_result["pmid"],
+            :doi => first_result["doi"]
+          }
         end
-        unless response["records"].length > 0
-          raise PMCIDConverterError.new("PMC ID Converter API returned no results", response)
-        end
-        first_result = response["records"].first
-        if first_result["status"] == "error"
-          raise PMCIDConverterError.new("PMC ID Converter API could not find this ID: #{id}", response)
-        end
-        {
-          :pmcid => first_result["pmcid"],
-          :pmid => first_result["pmid"],
-          :doi => first_result["doi"]
-        }
-      end
+       rescue OpenURI::HTTPError => ex
+         puts "****URI MISSING", uri, "\n";
+       end
     end
     
     def pubmed_search(id, id_type)


### PR DESCRIPTION
rake kept crashing with a 404 error in open(uri)

it happens on specefic papers:
http://www.pubmedcentral.nih.gov/utils/idconv/v1.0/?format=json&ids=280275800001

don't know the underlying cause, but at least this will allow rake to continue

thanks for the tool!
